### PR TITLE
Fix for the death message bug present in all Fabric versions.

### DIFF
--- a/mc2discord-1.18.x/fabric/src/main/java/fr/denisd3d/mc2discord/fabric/FabricEvents.java
+++ b/mc2discord-1.18.x/fabric/src/main/java/fr/denisd3d/mc2discord/fabric/FabricEvents.java
@@ -47,7 +47,7 @@ public class FabricEvents {
     }
 
     public static void onPlayerDeathEvent(ServerPlayer serverPlayer, DamageSource damageSource) {
-        MinecraftEvents.onPlayerDeathEvent(new PlayerEntity(serverPlayer.getGameProfile().getName(), serverPlayer.getDisplayName().getString(), serverPlayer.getGameProfile().getId()), new DeathEntity(damageSource.getMsgId(), serverPlayer.getCombatTracker().getDeathMessage().getString(), serverPlayer.getCombatTracker().getCombatDuration(), Optional.of(serverPlayer.getCombatTracker().mob).map(livingEntity -> livingEntity.getDisplayName().getString()).orElse(""), Optional.of(serverPlayer.getCombatTracker().mob).map(LivingEntity::getHealth).orElse(0.0f)));
+        MinecraftEvents.onPlayerDeathEvent(new PlayerEntity(serverPlayer.getGameProfile().getName(), serverPlayer.getDisplayName().getString(), serverPlayer.getGameProfile().getId()), new DeathEntity(damageSource.getMsgId(), damageSource.getLocalizedDeathMessage(serverPlayer).getString(), serverPlayer.getCombatTracker().getCombatDuration(), Optional.of(serverPlayer.getCombatTracker().mob).map(livingEntity -> livingEntity.getDisplayName().getString()).orElse(""), Optional.of(serverPlayer.getCombatTracker().mob).map(LivingEntity::getHealth).orElse(0.0f)));
     }
 
     public static void onAdvancementEvent(ServerPlayer serverPlayer, Advancement advancement) {

--- a/mc2discord-1.19.x/fabric/src/main/java/fr/denisd3d/mc2discord/fabric/FabricEvents.java
+++ b/mc2discord-1.19.x/fabric/src/main/java/fr/denisd3d/mc2discord/fabric/FabricEvents.java
@@ -49,7 +49,7 @@ public class FabricEvents {
     }
 
     public static void onPlayerDeathEvent(ServerPlayer serverPlayer, DamageSource damageSource) {
-        MinecraftEvents.onPlayerDeathEvent(new PlayerEntity(serverPlayer.getGameProfile().getName(), serverPlayer.getDisplayName().getString(), serverPlayer.getGameProfile().getId()), new DeathEntity(damageSource.getMsgId(), serverPlayer.getCombatTracker().getDeathMessage().getString(), serverPlayer.getCombatTracker().getCombatDuration(), Optional.of(serverPlayer.getCombatTracker().mob).map(livingEntity -> livingEntity.getDisplayName().getString()).orElse(""), Optional.of(serverPlayer.getCombatTracker().mob).map(LivingEntity::getHealth).orElse(0.0f)));
+        MinecraftEvents.onPlayerDeathEvent(new PlayerEntity(serverPlayer.getGameProfile().getName(), serverPlayer.getDisplayName().getString(), serverPlayer.getGameProfile().getId()), new DeathEntity(damageSource.getMsgId(), damageSource.getLocalizedDeathMessage(serverPlayer).getString(), serverPlayer.getCombatTracker().getCombatDuration(), Optional.of(serverPlayer.getCombatTracker().mob).map(livingEntity -> livingEntity.getDisplayName().getString()).orElse(""), Optional.of(serverPlayer.getCombatTracker().mob).map(LivingEntity::getHealth).orElse(0.0f)));
     }
 
     public static void onAdvancementEvent(ServerPlayer serverPlayer, Advancement advancement) {

--- a/mc2discord-1.20.1/fabric/src/main/java/fr/denisd3d/mc2discord/fabric/FabricEvents.java
+++ b/mc2discord-1.20.1/fabric/src/main/java/fr/denisd3d/mc2discord/fabric/FabricEvents.java
@@ -49,7 +49,7 @@ public class FabricEvents {
     }
 
     public static void onPlayerDeathEvent(ServerPlayer serverPlayer, DamageSource damageSource) {
-        MinecraftEvents.onPlayerDeathEvent(new PlayerEntity(serverPlayer.getGameProfile().getName(), serverPlayer.getDisplayName().getString(), serverPlayer.getGameProfile().getId()), new DeathEntity(damageSource.getMsgId(), serverPlayer.getCombatTracker().getDeathMessage().getString(), serverPlayer.getCombatTracker().getCombatDuration(), Optional.of(serverPlayer.getCombatTracker().mob).map(livingEntity -> livingEntity.getDisplayName().getString()).orElse(""), Optional.of(serverPlayer.getCombatTracker().mob).map(LivingEntity::getHealth).orElse(0.0f)));
+        MinecraftEvents.onPlayerDeathEvent(new PlayerEntity(serverPlayer.getGameProfile().getName(), serverPlayer.getDisplayName().getString(), serverPlayer.getGameProfile().getId()), new DeathEntity(damageSource.getMsgId(), damageSource.getLocalizedDeathMessage(serverPlayer).getString(), serverPlayer.getCombatTracker().getCombatDuration(), Optional.of(serverPlayer.getCombatTracker().mob).map(livingEntity -> livingEntity.getDisplayName().getString()).orElse(""), Optional.of(serverPlayer.getCombatTracker().mob).map(LivingEntity::getHealth).orElse(0.0f)));
     }
 
     public static void onAdvancementEvent(ServerPlayer serverPlayer, Advancement advancement) {

--- a/mc2discord-1.20.2/fabric/src/main/java/fr/denisd3d/mc2discord/fabric/FabricEvents.java
+++ b/mc2discord-1.20.2/fabric/src/main/java/fr/denisd3d/mc2discord/fabric/FabricEvents.java
@@ -50,7 +50,7 @@ public class FabricEvents {
     }
 
     public static void onPlayerDeathEvent(ServerPlayer serverPlayer, DamageSource damageSource) {
-        MinecraftEvents.onPlayerDeathEvent(new PlayerEntity(serverPlayer.getGameProfile().getName(), serverPlayer.getDisplayName().getString(), serverPlayer.getGameProfile().getId()), new DeathEntity(damageSource.getMsgId(), serverPlayer.getCombatTracker().getDeathMessage().getString(), serverPlayer.getCombatTracker().getCombatDuration(), Optional.of(serverPlayer.getCombatTracker().mob).map(livingEntity -> livingEntity.getDisplayName().getString()).orElse(""), Optional.of(serverPlayer.getCombatTracker().mob).map(LivingEntity::getHealth).orElse(0.0f)));
+        MinecraftEvents.onPlayerDeathEvent(new PlayerEntity(serverPlayer.getGameProfile().getName(), serverPlayer.getDisplayName().getString(), serverPlayer.getGameProfile().getId()), new DeathEntity(damageSource.getMsgId(), damageSource.getLocalizedDeathMessage(serverPlayer).getString(), serverPlayer.getCombatTracker().getCombatDuration(), Optional.of(serverPlayer.getCombatTracker().mob).map(livingEntity -> livingEntity.getDisplayName().getString()).orElse(""), Optional.of(serverPlayer.getCombatTracker().mob).map(LivingEntity::getHealth).orElse(0.0f)));
     }
 
     public static void onAdvancementEvent(ServerPlayer serverPlayer, AdvancementHolder advancement) {

--- a/mc2discord-1.20.x/fabric/src/main/java/fr/denisd3d/mc2discord/fabric/FabricEvents.java
+++ b/mc2discord-1.20.x/fabric/src/main/java/fr/denisd3d/mc2discord/fabric/FabricEvents.java
@@ -49,7 +49,7 @@ public class FabricEvents {
     }
 
     public static void onPlayerDeathEvent(ServerPlayer serverPlayer, DamageSource damageSource) {
-        MinecraftEvents.onPlayerDeathEvent(new PlayerEntity(serverPlayer.getGameProfile().getName(), serverPlayer.getDisplayName().getString(), serverPlayer.getGameProfile().getId()), new DeathEntity(damageSource.getMsgId(), serverPlayer.getCombatTracker().getDeathMessage().getString(), serverPlayer.getCombatTracker().getCombatDuration(), Optional.of(serverPlayer.getCombatTracker().mob).map(livingEntity -> livingEntity.getDisplayName().getString()).orElse(""), Optional.of(serverPlayer.getCombatTracker().mob).map(LivingEntity::getHealth).orElse(0.0f)));
+        MinecraftEvents.onPlayerDeathEvent(new PlayerEntity(serverPlayer.getGameProfile().getName(), serverPlayer.getDisplayName().getString(), serverPlayer.getGameProfile().getId()), new DeathEntity(damageSource.getMsgId(), damageSource.getLocalizedDeathMessage(serverPlayer).getString(), serverPlayer.getCombatTracker().getCombatDuration(), Optional.of(serverPlayer.getCombatTracker().mob).map(livingEntity -> livingEntity.getDisplayName().getString()).orElse(""), Optional.of(serverPlayer.getCombatTracker().mob).map(LivingEntity::getHealth).orElse(0.0f)));
     }
 
     public static void onAdvancementEvent(ServerPlayer serverPlayer, AdvancementHolder advancement) {

--- a/mc2discord-1.21.x/fabric/src/main/java/fr/denisd3d/mc2discord/fabric/FabricEvents.java
+++ b/mc2discord-1.21.x/fabric/src/main/java/fr/denisd3d/mc2discord/fabric/FabricEvents.java
@@ -49,7 +49,7 @@ public class FabricEvents {
     }
 
     public static void onPlayerDeathEvent(ServerPlayer serverPlayer, DamageSource damageSource) {
-        MinecraftEvents.onPlayerDeathEvent(new PlayerEntity(serverPlayer.getGameProfile().getName(), serverPlayer.getDisplayName().getString(), serverPlayer.getGameProfile().getId()), new DeathEntity(damageSource.getMsgId(), serverPlayer.getCombatTracker().getDeathMessage().getString(), serverPlayer.getCombatTracker().getCombatDuration(), Optional.of(serverPlayer.getCombatTracker().mob).map(livingEntity -> livingEntity.getDisplayName().getString()).orElse(""), Optional.of(serverPlayer.getCombatTracker().mob).map(LivingEntity::getHealth).orElse(0.0f)));
+        MinecraftEvents.onPlayerDeathEvent(new PlayerEntity(serverPlayer.getGameProfile().getName(), serverPlayer.getDisplayName().getString(), serverPlayer.getGameProfile().getId()), new DeathEntity(damageSource.getMsgId(), damageSource.getLocalizedDeathMessage(serverPlayer).getString(), serverPlayer.getCombatTracker().getCombatDuration(), Optional.of(serverPlayer.getCombatTracker().mob).map(livingEntity -> livingEntity.getDisplayName().getString()).orElse(""), Optional.of(serverPlayer.getCombatTracker().mob).map(LivingEntity::getHealth).orElse(0.0f)));
     }
 
     public static void onAdvancementEvent(ServerPlayer serverPlayer, AdvancementHolder advancement) {


### PR DESCRIPTION
Simple fix for the persistent "[Playername] died" bug instead of e.g. "[Playername] was shot by Skeleton]

For every Fabric version I changed the return for the OnPlayerDeathEvent method within the FabricEvents classes. 

It will now get the localized death message from the damagesource instead of the deathmessage from the player. I'm not a 100% sure why this is necessary, but I'm guessing its because of the ServerPlayer not actually receiving a death itself message on death. Don't quote me on that though...